### PR TITLE
Disable delete button if no meeting selected and fix inconsistent copy

### DIFF
--- a/components/preferences/PreferencesApplication.tsx
+++ b/components/preferences/PreferencesApplication.tsx
@@ -65,12 +65,13 @@ const PreferencesApplication = () => {
                         </IconWrapper>
                         {t("programs-focuses")}
                     </FormLabel>
-                    <Input
+                    {/* <Input
                         variant="outline"
                         boxShadow="1px 1px 8px -5px rgba(0, 0, 0, 0.4)"
                         placeholder="Search for a program or focus"
                         my={2}
                         onClick={(e: MouseEvent) => {
+                            return
                             dispatchAppContext({
                                 type: "ADD_PROGRAM",
                                 payload: {
@@ -83,7 +84,8 @@ const PreferencesApplication = () => {
                                 },
                             })
                         }}
-                    />
+                    /> */}
+                    Programs and focuses is not yet implemented.
                     <UnorderedList my={4} fontWeight="500">
                         {programs.map((program) => (
                             <ListItem mb={2} key={program.code}>
@@ -174,8 +176,9 @@ const PreferencesApplication = () => {
                         </IconWrapper>
                         {t("campus")}
                     </FormLabel>
-                    {JSON.stringify(campus, null, 2)} <br />
-                    TODO: Add campus selection
+                    Campus selection is not yet implemented.
+                    {/* {JSON.stringify(campus, null, 2)} <br />
+                    TODO: Add campus selection */}
                 </FormControl>
             </PreferencesSection>
 

--- a/components/preferences/PreferencesMeeting.tsx
+++ b/components/preferences/PreferencesMeeting.tsx
@@ -67,7 +67,7 @@ const PreferencesMeeting = () => {
                     iconProps={{
                         as: FaTruckMoving,
                     }}
-                    helperText="Show medium of delivery (OS, OA, IP)."
+                    helperText="Show medium of delivery (SY, AS, IP, etc.)."
                 >
                     {t("delivery-method")}
                 </PreferencesToggle>

--- a/components/sidebar/MeetingPicker.tsx
+++ b/components/sidebar/MeetingPicker.tsx
@@ -12,7 +12,6 @@ import {
     Flex,
     Grid,
     Icon,
-    Skeleton,
     Text,
     Tooltip,
     useColorModeValue,
@@ -98,19 +97,12 @@ const MeetingPicker = ({
                 mb={1}
             >
                 <CourseSubheading px={5}>{t(method)}</CourseSubheading>
-                <Icon
-                    cursor="pointer"
-                    as={FaTrashAlt}
-                    position="relative"
-                    top={1.5}
-                    fontSize="sm"
-                    pl={0.5}
-                    mr={7}
-                    opacity={
-                        userMeetings[identifier] &&
-                        userMeetings[identifier][method]
-                            ? ""
-                            : "0.5"
+                <button
+                    disabled={
+                        !(
+                            userMeetings[identifier] &&
+                            userMeetings[identifier][method]
+                        )
                     }
                     onClick={() => {
                         dispatch({
@@ -121,7 +113,22 @@ const MeetingPicker = ({
                             },
                         })
                     }}
-                />
+                >
+                    <Icon
+                        as={FaTrashAlt}
+                        position="relative"
+                        top={1.5}
+                        fontSize="sm"
+                        pl={0.5}
+                        mr={7}
+                        opacity={
+                            userMeetings[identifier] &&
+                            userMeetings[identifier][method]
+                                ? ""
+                                : "0.5"
+                        }
+                    />
+                </button>
             </Flex>
             <VStack spacing={0}>
                 {matchingMethod.map((section) => {


### PR DESCRIPTION
Disallow clicking the delete button if there is no meeting selected.
Additionally,
- remove cryptic text from Application preferences, and
- fix inconsistent delivery method (closes #15).