### PR TITLE
Fixed read-only notification and 'duplicate timetable' button text

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -313,7 +313,7 @@ const Header = ({ setSidebarOpen }: { setSidebarOpen: any }) => {
             isLoading={loading}
           >
             <Icon mr={{ md: 2 }} as={BiDuplicate} />
-            {t("duplicate-timetable")}
+            {t("duplicate-table")}
           </Button>
         )}
         <ButtonGroup

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -108,6 +108,12 @@ function Application({ Component, pageProps }: AppProps) {
     }
   }, [size, toast])
 
+  useEffect(() => {
+    if (toast.isActive("warn-not-allowed")) {
+      toast.close("warn-not-allowed")
+    }
+  })
+
   return (
     <React.Fragment>
       <Script id="heap">


### PR DESCRIPTION
The read-only notification that pops up when viewing a shared timetable does not go away when exiting to the dashboard. It now does. The button to duplicate a timetable read as "duplicate-timetable" due to a wrong translation. It now doesn't. Hallelujah