### PR TITLE
Set the default OS modifier to Ctrl + K

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -78,8 +78,8 @@ const Header = ({ setSidebarOpen }: { setSidebarOpen: any }) => {
   const [osModifier, setOsModifier] = useState("")
 
   useEffect(() => {
-        if (navigator.userAgent.indexOf("Mac OS X") !== -1) return setOsModifier("⌘")
-        setOsModifier("Ctrl + ")
+    if (navigator.userAgent.indexOf("Mac OS X") !== -1) return setOsModifier("⌘")
+    setOsModifier("Ctrl + ")
   }, [])
 
   const router = useRouter()

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -78,8 +78,8 @@ const Header = ({ setSidebarOpen }: { setSidebarOpen: any }) => {
   const [osModifier, setOsModifier] = useState("")
 
   useEffect(() => {
-    if (navigator.userAgent.indexOf("Mac OS X") !== -1) setOsModifier("⌘")
-    if (navigator.userAgent.indexOf("Windows") !== -1) setOsModifier("Ctrl + ")
+        if (navigator.userAgent.indexOf("Mac OS X") !== -1) return setOsModifier("⌘")
+        setOsModifier("Ctrl + ")
   }, [])
 
   const router = useRouter()


### PR DESCRIPTION
Before, it was set up to only change the modifier for a Windows or macOS machine, so a Linux machine would just show `(K)`. This fixes that and shows `(Ctrl + K)` on Linux and Windows while showing `(⌘K)` on macOS